### PR TITLE
Update README for new repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,12 @@ You should have `node` (>= 7.6.0), `npm` (>= 3.10), and `TypeScript`  (>= 2.0.0)
 https://github.com/strongloop/loopback-next/wiki/Installation
 
 ```
-git clone https://github.com/strongloop/loopback-next-ts-starter.git
+git clone https://github.com/strongloop/loopback-next-hello-world.git
+cd loopback-next-hello-world
 npm install -S @loopback/core
+npm install
 npm start
+# On another terminal, run the following curl command
 curl localhost:3000/helloworld?name=Joe
 # you should see "Hello world Joe!"
 ```
@@ -40,7 +43,7 @@ curl localhost:3000/helloworld?name=Joe
 
 ## Useful app commands
 
-- Clone this project: `git clone https://github.com/strongloop/loopback-next-ts-starter.git`
+- Clone this project: `git clone https://github.com/strongloop/loopback-next-hello-world.git`
 - Building this project: `npm run build`
 - Running the application: `npm start`
 - Test your application: `npm test`

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "loopback-next-ts-starter",
+  "name": "loopback-next-hello-world",
   "version": "1.0.0",
   "description": "A starting point for LoopBack.next apps using TypeScript",
   "main": "dist/index.js",
@@ -13,7 +13,8 @@
   "keywords": [
     "loopback-next",
     "typescript",
-    "starter"
+    "starter",
+    "hello-world"
   ],
   "author": "IBM",
   "license": "MIT",


### PR DESCRIPTION
Following the setup instruction in README, I've made the changes below to make it easier to follow:
- repo name changed from `loopback-next-ts-starter` to `loopback-next-hello-world`
- Add command `npm install` 
  - seems to be needed for me, besides `npm install -S @loopback/core` 