### PR TITLE
recover resolver for app start

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,8 @@ import {RestServer, RestBindings} from '@loopback/rest';
 if (require.main === module.parent) {
   // executed from the console
   const app = new HelloWorldApp();
-  (async function main() {
-    await app.start();
-  })();
+  app.start().catch(err => {
+    console.error('Cannot start the application! ', err);
+    process.exit(1);
+  });
 }

--- a/test/acceptance/error-handling.acceptance.ts
+++ b/test/acceptance/error-handling.acceptance.ts
@@ -1,0 +1,30 @@
+import {expect} from '@loopback/testlab';
+import * as cp from 'child_process';
+import * as path from 'path';
+import * as http from 'http';
+
+describe('App error handler (acceptance)', () => {
+  let httpServer: http.Server;
+
+  before(givenListeningServer);
+  after(stopHttpServer);
+
+  it('throws error for not starting', function() {
+    this.timeout(5000);
+    const child = cp.spawnSync('node', ['.'], {
+      cwd: path.resolve(__dirname, '../..'),
+    });
+    expect(child.stderr.toString()).to.match(/Cannot start the application!/);
+    expect(child.stderr.toString()).to.match(/EADDRINUSE/);
+    expect(child.status).to.equal(1);
+  });
+
+  async function givenListeningServer() {
+    httpServer = http.createServer();
+    await httpServer.listen(3000);
+  }
+
+  function stopHttpServer() {
+    httpServer.close();
+  }
+});


### PR DESCRIPTION
### Description

I had removed the code to handle the Promise resolution or rejection from `app.start` in #23, so adding it back.